### PR TITLE
Create start.js

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,0 +1,2 @@
+const start = require('index.js');
+start(client);


### PR DESCRIPTION
I think this will fix the `TypeError: require(...) is not a function` error.
```js
const { Client } = require("discord.js")//Importing client
const client = new Client()//creating a new discord.js client
require("discordjs-activity")(client)
```
Changed:
```js
const { Client } = require("discord.js")//Importing client
const client = new Client()//creating a new discord.js client
const start = require("discordjs-activity")//Importing this package and initiating it with the client
start(client)
```