### PR TITLE
Fix the id for youtube_together invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Client ID: `755827207812677713`
 ### Betrayal.io
 Application Name: `betrayal`
 
-Client ID: `773336526917861400`
+Client ID: `880218394199220334`
 ![](https://media.discordapp.net/attachments/749254970003423345/849891725144752178/unknown.png)
 ### YouTube Together
 Application Name: `youtube_together`

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ Structures.extend('VoiceChannel', VoiceChannel => {
     constructor(client, data) {
       super(client, data);
       this.applications = {
-        "youtube_together": "755600276941176913",
+        "youtube_together": "880218394199220334",
         "watch_together_dev": "880218832743055411",
         "fishington": "814288819477020702",
         "chess_in_the_park": "832012774040141894",


### PR DESCRIPTION
The old id is deprecated and will show this error when you try to use it.
![oldidbrokey](https://user-images.githubusercontent.com/55406094/146766161-0e98701d-bf22-4a8b-bc50-c55880e87f9e.png)

