### PR TITLE
Fix npm publish error:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordjs-activity",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "An simple package to create an Activity in Discord Voice Channel using Discord.js v12",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix npm publish action error:
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/discordjs-activity - You cannot publish over the previously published versions: 1.4.1.

Changing version in package.json from 1.4.1 to 1.4.2